### PR TITLE
Updated Actions to use V4 and Updated Assigning Output ENV Variable

### DIFF
--- a/.github/workflows/jobs_on_release.yaml
+++ b/.github/workflows/jobs_on_release.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Latest tag Applier
         uses: EndBug/latest-tag@latest
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build Dockerfile Container & Run App in it
         uses: Nightwind-Developments/debian-control-file-builder@latest
@@ -38,7 +38,7 @@ jobs:
         run: ls ${{ steps.container.outputs.control_file_path }}
 
       - name: Upload Generated Control File
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: public-generated-control-file-1
           path: "${{ steps.container.outputs.control_file_path }}"
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build Dockerfile Container & Run App in it
         uses: Nightwind-Developments/debian-control-file-builder@latest
@@ -67,7 +67,7 @@ jobs:
         run: ls ${{ steps.container.outputs.control_file_path }}
 
       - name: Upload Generated Control File
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: public-generated-control-file-2
           path: "${{ steps.container.outputs.control_file_path }}"

--- a/.github/workflows/latest_file_builder.yaml
+++ b/.github/workflows/latest_file_builder.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
     
       - name: Build Dockerfile Container & Run App in it
         uses: ./
@@ -28,7 +28,7 @@ jobs:
         run: ls ${{ steps.container.outputs.control_file_path }}
         
       - name: Upload Generated Control File
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: locally-generated-control-file-1
           path: "${{ steps.container.outputs.control_file_path }}"
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build Dockerfile Container & Run App in it
         uses: ./
@@ -57,7 +57,7 @@ jobs:
         run: ls ${{ steps.container.outputs.control_file_path }}
 
       - name: Upload Generated Control File
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: locally-generated-control-file-2
           path: "${{ steps.container.outputs.control_file_path }}"

--- a/deb_control_builder.py
+++ b/deb_control_builder.py
@@ -173,8 +173,11 @@ class DebControl:
         for i in self.OTHER_DATA_KEYS:
             build_file.write(self.generate_line_from_data(i))
 
-        print("::set-output name=control_file_path::" + output_path_full)
-
+        # Sets a GitHub Actions Output variable
+        gh_outputs_file_path = os.getenv("GITHUB_OUTPUT")
+        gh_outputs_file = open(gh_outputs_file_path, "a")
+        gh_outputs_file.write("control_file_path=" + output_path_full + "\n")
+        gh_outputs_file.close()
 
 # Main Function to Run on Start
 @click.command()


### PR DESCRIPTION
Actions using V2 are deprecated and have been updated to use V4, specifically:

- actions/checkout@v4
- actions/upload-artifact@v4

The way output variables are set has been changed to updating a GitHub Environments Variable file at the `$GITHUB_OUTPUT` variable.